### PR TITLE
feat: add open in new window functionality for file search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Keyboard shortcuts:
 - `↑↓` - Navigate search results
 - `Enter` - Open selected file
 - `ESC` - Clear search and unfocus
+- `Ctrl/Cmd + Click` or `Middle Click` - Open file in new tab/window
+- `Shift + Click` - Open file in new tab/window
 
 ## Color Themes
 

--- a/lib/html-generator.js
+++ b/lib/html-generator.js
@@ -2001,7 +2001,7 @@ function generateIndexHtmlWithSearch(folderPath, files, port, forceTheme = null)
         />
         <span class="search-mode" id="searchModeIndicator">in names & paths</span>
         <span class="search-help">
-            <kbd>TAB</kbd> focus • <kbd>SHIFT+TAB</kbd> mode • <kbd>↑↓</kbd> select • <kbd>ENTER</kbd> open
+            <kbd>TAB</kbd> focus • <kbd>SHIFT+TAB</kbd> mode • <kbd>↑↓</kbd> select • <kbd>ENTER</kbd> open • <kbd>Ctrl/Cmd+Click</kbd> new tab
         </span>
     </div>
 
@@ -2149,6 +2149,25 @@ function generateIndexHtmlWithSearch(folderPath, files, port, forceTheme = null)
                     } else if (e.key === 'ArrowUp' && selectedFileIndex > 0) {
                         selectFile(selectedFileIndex - 1);
                     }
+                }
+            }
+
+            // Update cursor for file items when modifier keys are pressed
+            if (e.ctrlKey || e.metaKey || e.shiftKey) {
+                const hoveredItem = document.querySelector('.file-item:hover');
+                if (hoveredItem) {
+                    hoveredItem.style.cursor = 'copy';
+                }
+            }
+        });
+
+        // Global keyboard handler for modifier key release
+        document.addEventListener('keyup', (e) => {
+            // Reset cursor when modifier keys are released
+            if (!e.ctrlKey && !e.metaKey && !e.shiftKey) {
+                const hoveredItem = document.querySelector('.file-item:hover');
+                if (hoveredItem) {
+                    hoveredItem.style.cursor = 'default';
                 }
             }
         });
@@ -2610,22 +2629,64 @@ function generateIndexHtmlWithSearch(folderPath, files, port, forceTheme = null)
         function setupFileClickHandlers() {
             const fileItems = document.querySelectorAll('.file-item');
             fileItems.forEach(item => {
+                // Add cursor style changes on modifier key hold
+                item.addEventListener('mouseenter', (e) => {
+                    if (e.ctrlKey || e.metaKey || e.shiftKey) {
+                        item.style.cursor = 'copy';
+                    }
+                });
+
+                item.addEventListener('mouseleave', (e) => {
+                    item.style.cursor = 'default';
+                });
+
+                item.addEventListener('mousemove', (e) => {
+                    if (e.ctrlKey || e.metaKey || e.shiftKey) {
+                        item.style.cursor = 'copy';
+                    } else {
+                        item.style.cursor = 'default';
+                    }
+                });
+
                 item.addEventListener('click', (e) => {
                     e.preventDefault();
-                    // Switch focus to list when clicking
-                    if (focusMode !== 'list') {
-                        setFocusMode('list');
-                    }
-                    // Select the clicked item
-                    updateVisibleFiles();
-                    const index = visibleFiles.indexOf(item);
-                    if (index !== -1) {
-                        selectFile(index);
-                    }
-                    // Open the file
                     const filePath = item.dataset.path;
-                    if (filePath) {
-                        showOverlay(filePath);
+
+                    // Check for modifier keys or middle click
+                    const openInNewWindow = e.ctrlKey || e.metaKey || e.shiftKey || e.button === 1;
+
+                    if (openInNewWindow && filePath) {
+                        // Open in new window/tab
+                        const url = window.location.origin + '/view?file=' + encodeURIComponent(filePath);
+                        window.open(url, '_blank');
+                    } else {
+                        // Original behavior - open in overlay
+                        // Switch focus to list when clicking
+                        if (focusMode !== 'list') {
+                            setFocusMode('list');
+                        }
+                        // Select the clicked item
+                        updateVisibleFiles();
+                        const index = visibleFiles.indexOf(item);
+                        if (index !== -1) {
+                            selectFile(index);
+                        }
+                        // Open the file in overlay
+                        if (filePath) {
+                            showOverlay(filePath);
+                        }
+                    }
+                });
+
+                // Handle middle mouse button (auxclick event)
+                item.addEventListener('auxclick', (e) => {
+                    if (e.button === 1) { // Middle button
+                        e.preventDefault();
+                        const filePath = item.dataset.path;
+                        if (filePath) {
+                            const url = window.location.origin + '/view?file=' + encodeURIComponent(filePath);
+                            window.open(url, '_blank');
+                        }
                     }
                 });
             });


### PR DESCRIPTION
Closes #2

## Summary
- Added Ctrl/Cmd+Click and middle-click support to open files in new tabs
- Added Shift+Click support for opening in new windows
- Visual cursor feedback when modifier keys are held
- Updated documentation with new keyboard shortcuts

## Test plan
- [ ] Start the server with `mm .` in a folder with markdown files
- [ ] Try clicking on files normally (should open in overlay)
- [ ] Try Ctrl+Click or Cmd+Click (should open in new tab)
- [ ] Try Shift+Click (should open in new tab)
- [ ] Try middle-clicking (should open in new tab)
- [ ] Verify cursor changes to 'copy' style when hovering with modifier keys
- [ ] Test in Chrome, Firefox, and Safari

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Open files in a new tab/window via Ctrl/Cmd+Click, Shift+Click, or Middle-click in file listings.
  * Dynamic cursor feedback when holding Ctrl/Cmd/Shift to indicate new-tab action; resets on key release.
  * Updated in-app search help text to surface the new shortcut.
* **Documentation**
  * Added keyboard/mouse shortcuts to README for opening files in a new tab/window (Ctrl/Cmd+Click, Middle-click, Shift+Click).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->