### PR TITLE
fix: syntax highlighting not working due to CSS specificity issue

### DIFF
--- a/lib/html-generator.js
+++ b/lib/html-generator.js
@@ -611,7 +611,8 @@ function generateHtmlFromMarkdown(markdown, title, isIndex, isServer, forceTheme
             overflow: hidden;
         }
 
-        pre code {
+        /* Only apply transparent background to code blocks without syntax highlighting */
+        pre code:not([class*="language-"]) {
             padding: 0;
             background: transparent;
         }


### PR DESCRIPTION
The CSS rule `pre code { background: transparent; }` was overriding Prism.js syntax highlighting styles.

Fixed by making the selector more specific: `pre code:not([class*="language-"])` to only apply to non-highlighted code blocks.

Fixes #7

Generated with [Claude Code](https://claude.ai/code)