### PR TITLE
fix: enable browser find in document overlay

### DIFF
--- a/lib/html-generator.js
+++ b/lib/html-generator.js
@@ -3123,7 +3123,8 @@ function generateIndexHtmlWithSearch(folderPath, files, port, forceTheme = null)
 
             // Show overlay with animation
             overlay.classList.add('visible');
-            document.body.style.overflow = 'hidden';
+            // Removed document.body.style.overflow = 'hidden' to allow browser find to work properly
+            // The overlay-content has its own scrolling via 'overflow: auto'
 
             // Set title
             overlayTitle.textContent = filePath;
@@ -3244,7 +3245,7 @@ function generateIndexHtmlWithSearch(folderPath, files, port, forceTheme = null)
             // Wait for animation to complete before hiding
             setTimeout(() => {
                 overlay.classList.remove('visible');
-                document.body.style.overflow = '';
+                // Removed resetting of document.body.style.overflow since we no longer set it
 
                 // Restore the saved search state
                 restoreSearchState();


### PR DESCRIPTION
Fixes #4

## Description
Removed document.body.style.overflow = 'hidden' from overlay show/hide functions to allow browser's native find (Ctrl+F/Cmd+F) to work properly. The overlay content has its own scrolling, so hiding body overflow was unnecessary and interfered with browser find functionality.

## Changes
- Removed `document.body.style.overflow = 'hidden'` from `showOverlay()` function
- Removed the corresponding reset in `hideOverlay()` function

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed global page scroll lock when overlays open; page can scroll normally while the overlay is displayed.
  * Overlay content now scrolls within its own area for better usability on small screens.
  * Eliminates scroll state resets when closing overlays, reducing layout jumps and content shifts.
  * Prevents loss of scroll position caused by previous behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->